### PR TITLE
Fix PVS warnings

### DIFF
--- a/inipp/inipp.h
+++ b/inipp/inipp.h
@@ -124,8 +124,11 @@ public:
 	void parse(std::basic_istream<CharT> & is) {
 		String line;
 		String section;
-		while (!is.eof()) {
+		while (true) {
 			std::getline(is, line);
+			if (is.eof() || is.fail()) {
+				break;
+			}
 			detail::ltrim(line);
 			detail::rtrim(line);
 			const auto length = line.length();


### PR DESCRIPTION
This pull request fixes problems, detected by PVS-Studio static analyzer.
I'm not expert in C++, but it really seems to me that current implementation will enter endless loop if reading from `is` fails.

Analyzer output before changes:
```
.../inipp.h:127:1: error: V663 Infinite loop is possible. The 'cin.eof()' condition is insufficient to break from the loop. Consider adding the 'cin.fail()' function call to the conditional expression.
.../inipp.h:127:1: warning: V1024 The 'is' stream is checked for EOF before reading from it, but is not checked after reading. Potential use of invalid data.
```