### PR TITLE
Refactored ltrim & rtrim to avoid crashes for non-ASCII characters

### DIFF
--- a/inipp/inipp.h
+++ b/inipp/inipp.h
@@ -44,13 +44,13 @@ template <class CharT>
 inline void ltrim(std::basic_string<CharT> & s) {
 	s.erase(s.begin(),
                 std::find_if(s.begin(), s.end(),
-                             [](int ch) { return !std::isspace(ch); }));
+                             [](int ch) { return ch < -1 ? true : !std::isspace(ch); }));
 }
 
 template <class CharT>
 inline void rtrim(std::basic_string<CharT> & s) {
 	s.erase(std::find_if(s.rbegin(), s.rend(),
-                             [](int ch) { return !std::isspace(ch); }).base(),
+                             [](int ch) { return ch < -1 ? true : !std::isspace(ch); }).base(),
                 s.end());
 }
 


### PR DESCRIPTION
### Problem
If ini file is not ASCII (for example UTF-8/16 or Unicode), trimming functions would fail in debug assertion on MSVC.

### Solution (band aid)
Check if character could be represented and only if it can, call std::isspace() with it and  leave "as is" otherwise.

### Notes
I'd rather have full overload of std::isspace with std::locale as parameter, or a more suffisticated encoding hadling, but this would do nicely...