### PR TITLE
Cpp-11 compatibility

### DIFF
--- a/inipp/inipp.h
+++ b/inipp/inipp.h
@@ -190,22 +190,22 @@ public:
 private:
 	typedef std::list<std::pair<String, String> > Symbols;
 
-	auto local_symbol(const String & name) const {
+	const String local_symbol(const String & name) const {
 		return char_interpol + (char_interpol_start + name + char_interpol_end);
 	}
 
-	auto global_symbol(const String & sec_name, const String & name) const {
+	const String global_symbol(const String & sec_name, const String & name) const {
 		return local_symbol(sec_name + char_interpol_sep + name);
 	}
 
-	auto local_symbols(const String & sec_name, const Section & sec) const {
+	const Symbols local_symbols(const String & sec_name, const Section & sec) const {
 		Symbols result;
 		for (const auto & val : sec)
 			result.push_back(std::make_pair(local_symbol(val.first), global_symbol(sec_name, val.first)));
 		return result;
 	}
 
-	auto global_symbols() const {
+	const Symbols global_symbols() const {
 		Symbols result;
 		for (const auto & sec : sections)
 			for (const auto & val : sec.second)


### PR DESCRIPTION
Hello again,
I just wanted to share my changes that allow minimum Cpp version to be dropped down from C++14 to C++11.
I think it might be useful for not-so-big-and-sophisticated custom compilers (like IoT ones etc),
and (as far as I'm aware) it does not hurt performance on compilers that support newer versions,
because usually only the minimum required feature set is specified, and compiler is free to promote it to newer version on its own.
The change also relates purely to syntax, so for example the generated assembly on my machine is exactly
(and I do mean **exactly** ) the same for both versions, for both no- and full optimization enabled.
(-O0 and -O2 in examples below)

Original: [Example](https://godbolt.org/z/1dhWqh)
Updated: [Example](https://godbolt.org/z/dKxfYo)