### PR TITLE
Old (Visual) Basic comments

### DIFF
--- a/inipp/inipp.h
+++ b/inipp/inipp.h
@@ -24,6 +24,7 @@ SOFTWARE.
 
 #pragma once
 
+#include <array>
 #include <cstring>
 #include <string>
 #include <iostream>
@@ -102,14 +103,15 @@ public:
 	Sections sections;
 	std::list<String> errors;
 
-	static const CharT char_section_start  = (CharT)'[';
-	static const CharT char_section_end    = (CharT)']';
-	static const CharT char_assign         = (CharT)'=';
-	static const CharT char_comment        = (CharT)';';
-	static const CharT char_interpol       = (CharT)'$';
-	static const CharT char_interpol_start = (CharT)'{';
-	static const CharT char_interpol_sep   = (CharT)':';
-	static const CharT char_interpol_end   = (CharT)'}';
+	static const CharT char_section_start  = static_cast<CharT>('[');
+	static const CharT char_section_end    = static_cast<CharT>(']');
+	static const CharT char_assign         = static_cast<CharT>('=');
+	static const CharT char_comment		   = static_cast<CharT>(';');
+	static const CharT char_comment_vb     = static_cast<CharT>('\'');
+	static const CharT char_interpol       = static_cast<CharT>('$');
+	static const CharT char_interpol_start = static_cast<CharT>('{');
+	static const CharT char_interpol_sep   = static_cast<CharT>(':');
+	static const CharT char_interpol_end   = static_cast<CharT>('}');
 
 	static const int max_interpolation_depth = 10;
 
@@ -134,7 +136,7 @@ public:
 			if (length > 0) {
 				const auto pos = line.find_first_of(char_assign);
 				const auto & front = line.front();
-				if (front == char_comment) {
+				if (isComment(front)) {
 					continue;
 				}
 				else if (front == char_section_start) {
@@ -185,6 +187,19 @@ public:
 	void clear() {
 		sections.clear();
 		errors.clear();
+	}
+
+	inline bool isComment(const CharT & ch) const noexcept {
+		static const std::array<const CharT, 2> comment_starters = { 
+			static_cast<const CharT>(char_comment),  static_cast<const CharT>(char_comment_vb) };
+		
+		bool is_comment = false;
+		for (const auto & c: comment_starters) {
+			if (ch == c)	{
+				is_comment = true;
+			}
+		}
+		return is_comment;
 	}
 
 private:


### PR DESCRIPTION
Hello again,
it so happens that one of the first .ini that I parsed was (apparently) old Visual Basic- styled ini, which used `'` as comment starters. I am not aware if there is a "standart" comment starter character (usually I've seen `;` used as such) but nevertheless this thing exists.

So I quickly put together an addition that originally looked like this
```c++
/* ... */
static const CharT char_comment_vb  =  static_cast<CharT>('\'');
/* ... */
void parse(std::basic_istream<CharT> & is)
{
    /* ... */
    const auto & front = line.front();
    if (front == char_comment || front == char_comment_vb) 
    { /* ... */ } 
```
from which I then separated `(front == char_comment || front == char_comment_vb)` into function `bool isComment(const CharT & ch)`.

However, then it started looking like a table of comment starters would be an easier thing to have (see diff), 
but I was unable to define and parameterise `static std::array` member variable that would default to `std::array<const CharT, 1>(char_comment)` or if not defaulted would deduce its size and statically initialize on passed template parameters like so
```c++
Ini<char, ';', '\''> my_ini();
```
and would default to the ususal ';' if none given:
```c++
Ini<char> my_ini();
```


At that point I realized that this whole thing is starting to feel like overengeneering and kind of defeats the purpose of your library (mainly the `simplicity` aspect of it) so I dropped the whole parameterising thing.

Nevertheless I thought it would be nice to share this thing with you.

P.S. Addition tries to adhere to both coding styles: each separate char as static named member variable, and a function static array constructed from these characters, which wastes two `CharT` worth of space. So the ideal would most likely be either one (or neither ;) )