### PR TITLE
Fix unittest in linux

### DIFF
--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -2,3 +2,14 @@ add_executable(headertest headertest.cpp)
 add_executable(unittest unittest.cpp)
 add_test(test0 headertest)
 add_test(test1 unittest)
+
+function(glob_copy src_wildcard dest)
+    file(GLOB SRC ${CMAKE_CURRENT_SOURCE_DIR}/${src_wildcard})
+    file(COPY ${SRC} DESTINATION ${dest})
+endfunction()
+
+# Copying ini files to build directory
+glob_copy(*.ini ${CMAKE_BINARY_DIR}/unittest)
+
+# Copying output files to build directory
+glob_copy(*.output ${CMAKE_BINARY_DIR}/unittest)


### PR DESCRIPTION
The test INIs and outputs are not getting copied in the build directory due to which while running the unit tests and header tests using CTest gives `std::runtime_error expected true`. This PR fixes this issue.