### PR TITLE
Dont parse negative unsigned

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Simple header-only C++ ini parser and generator.
 * Simple design and implementation.
 * Permissive MIT license.
 
+## Requirements
+
+* C++14
+
+
 ## Example
 
 ```cpp

--- a/inipp/inipp.h
+++ b/inipp/inipp.h
@@ -33,6 +33,7 @@ SOFTWARE.
 #include <functional>
 #include <cctype>
 #include <sstream>
+#include <type_traits>
 
 namespace inipp {
 
@@ -72,6 +73,11 @@ inline bool replace(std::basic_string<CharT> & str, const std::basic_string<Char
 
 template <typename CharT, typename T>
 inline bool extract(const std::basic_string<CharT> & value, T & dst) {
+    if (std::is_unsigned<T>::value && value.size() > 0 && value[0] == '-')
+    {
+        return false;
+    }
+
 	CharT c;
 	std::basic_istringstream<CharT> is{ value };
 	T result;


### PR DESCRIPTION
This patch makes the parser fail when parsing negative numbers for unsigned types, rather than wrapping them around (I am not sure if this will break the tests though, I tried running them even before the patch, and they failed on my machine, so I must be doing something wrong there, or it may be something to do with my compiler)