### PR TITLE
Create proper target inipp and alias inipp::inipp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,18 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0)
+
 project(inipp)
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-include_directories("inipp/")
-install(FILES inipp/inipp.h DESTINATION include)
-include(CTest)
-if (BUILD_TESTING)
-    add_subdirectory("unittest/")
+
+add_library(inipp INTERFACE)
+add_library(inipp::inipp ALIAS inipp)
+
+target_include_directories(inipp SYSTEM INTERFACE inipp)
+
+target_compile_features(inipp INTERFACE cxx_std_11)
+
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  include(CTest)
+endif()
+
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
+  add_subdirectory(unittest)
 endif()

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -1,11 +1,15 @@
 add_executable(headertest headertest.cpp)
+target_link_libraries(headertest PRIVATE inipp::inipp)
+
 add_executable(unittest unittest.cpp)
+target_link_libraries(unittest PRIVATE inipp::inipp)
+
 add_test(test0 headertest)
 add_test(test1 unittest)
 
 function(glob_copy src_wildcard dest)
-    file(GLOB SRC ${CMAKE_CURRENT_SOURCE_DIR}/${src_wildcard})
-    file(COPY ${SRC} DESTINATION ${dest})
+  file(GLOB SRC ${CMAKE_CURRENT_SOURCE_DIR}/${src_wildcard})
+  file(COPY ${SRC} DESTINATION ${dest})
 endfunction()
 
 # Copying ini files to build directory


### PR DESCRIPTION
This PR creates a proper interface target for inipp and utilizes some modern CMake features (e.g. [target_compile_features](https://cmake.org/cmake/help/latest/command/target_compile_features.html)).

E.g. example of adding inipp to another CMake project by directly fetching it from github:
```CMake
FetchContent_Declare(inipp GIT_REPOSITORY https://github.com/mcmtroffaes/inipp.git)
FetchContent_MakeAvailable(inipp)
target_link_libraries(MyTarget PRIVATE inipp::inipp)
```