### PR TITLE
Add fuzzing by way of ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+COPY . $SRC/inipp
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/inipp

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,4 @@
+# ClusterFuzzLite set up
+
+This folder contains a fuzzing set for [ClusterFuzzLite](https://google.github.io/clusterfuzzlite).
+        

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -eu
+
+mkdir build
+cd build
+cmake ../
+make
+
+# Copy all fuzzer executable to $OUT/
+$CXX $CFLAGS $LIB_FUZZING_ENGINE \
+  $SRC/inipp/.clusterfuzzlite/parse_fuzzer.cpp \
+  -o $OUT/parse_fuzzer \
+  -I$SRC/inipp/inipp

--- a/.clusterfuzzlite/parse_fuzzer.cpp
+++ b/.clusterfuzzlite/parse_fuzzer.cpp
@@ -1,0 +1,15 @@
+
+#include <inipp.h>
+#include <sstream>
+#include <string>
+
+using namespace inipp;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  std::string fuzz_input(reinterpret_cast<const char *>(data), size);
+  std::istringstream fuzz_stream(fuzz_input);
+  Ini<char> ini;
+  ini.parse(fuzz_stream);
+
+  return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c++        

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c++
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs.

I added a fuzzer that targets the parsing logic, and currently set the timeout of CFLite to 100 seconds. CFLite will flag if the fuzzer finds any issues in the code introduced by a PR.